### PR TITLE
utilizar validação também sem REQUIRED no input

### DIFF
--- a/lib/ngCpfCnpj.js
+++ b/lib/ngCpfCnpj.js
@@ -16,7 +16,7 @@
 
         link: function(scope, elm, attrs, ctrl) {
           scope.$watch(attrs.ngModel, function(newVal, oldVal) {
-            ctrl.$setValidity( 'cpf', CPF.isValid(newVal) );
+            ctrl.$setValidity( 'cpf', newVal ? CPF.isValid(newVal) : true );
           });
         }
 
@@ -35,7 +35,7 @@
 
         link: function(scope, elm, attrs, ctrl) {
           scope.$watch(attrs.ngModel, function(newVal, oldVal) {
-            ctrl.$setValidity( 'cnpj', CNPJ.isValid(newVal) );
+            ctrl.$setValidity( 'cnpj', newVal ? CNPJ.isValid(newVal) : true );
           });
         }
 


### PR DESCRIPTION
possibilidade de usar ng-cpf e ng-cnpj sem required no input.
antes se você não tivesse o required no input o form ficaria inválido.. agora se não tiver o required e mandar um input em branco o campo é valido e o form também..
