### PR TITLE
Altera $watch para $parsers

### DIFF
--- a/lib/ngCpfCnpj.js
+++ b/lib/ngCpfCnpj.js
@@ -15,9 +15,15 @@
         require: 'ngModel',
 
         link: function(scope, elm, attrs, ctrl) {
-          scope.$watch(attrs.ngModel, function(newVal, oldVal) {
-            ctrl.$setValidity( 'cpf', CPF.isValid(newVal) );
-          });
+			ctrl.$parsers.unshift(function (viewValue) {
+				if (CPF.isValid(viewValue)) {
+					ctrl.$setValidity('cpf', true);
+					return viewValue;
+				} else {
+					ctrl.$setValidity('cpf', false);
+					return undefined;
+				}
+			});
         }
 
       };
@@ -34,9 +40,15 @@
         require: 'ngModel',
 
         link: function(scope, elm, attrs, ctrl) {
-          scope.$watch(attrs.ngModel, function(newVal, oldVal) {
-            ctrl.$setValidity( 'cnpj', CNPJ.isValid(newVal) );
-          });
+			ctrl.$parsers.unshift(function (viewValue) {
+				if (CNPJ.isValid(viewValue)) {
+					ctrl.$setValidity('cnpj', true);
+					return viewValue;
+				} else {
+					ctrl.$setValidity('cnpj', false);
+					return undefined;
+				}
+			});
         }
 
       };


### PR DESCRIPTION
Altera observer para $parsers para manter compatibilidade com ng-change.
Quando o evento change (ng-change) é chamado, o valor $valid do form
ainda não foi atualizado por que o observer ($watch) ainda não foi
chamado.
Utilizando $parsers, o change é chamado após a validação.

Obs.: Obrigado pelo código :)
