### PR TITLE
Permitir que um CNPJ ou CPF nulo seja considerado como válido.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bower_components
+*~

--- a/lib/ngCpfCnpj.js
+++ b/lib/ngCpfCnpj.js
@@ -1,46 +1,63 @@
 /* global angular, CPF, CNPJ */
 (function(window){
 
-  'use strict';
+    'use strict';
 
-  var module = angular.module('ngCpfCnpj', []);
+    var module = angular.module('ngCpfCnpj', []);
 
-  if( window.CPF ) {
+    if( window.CPF ) {
 
-    module.directive('ngCpf', function() {
-      return {
+        module.directive('ngCpf', function() {
+            return {
 
-        restrict: 'A',
+                restrict: 'A',
 
-        require: 'ngModel',
+                require: 'ngModel',
 
-        link: function(scope, elm, attrs, ctrl) {
-          scope.$watch(attrs.ngModel, function(newVal, oldVal) {
-            ctrl.$setValidity( 'cpf', CPF.isValid(newVal) );
-          });
-        }
+                link: function(scope, elm, attrs, ctrl) {
+                    scope.$watch(attrs.ngModel, function(newVal, oldVal) {
+                        if ( newVal == null ) {
+                            ctrl.$setValidity( 'cpf', true );
+                            return;
+                        }
 
-      };
-    });
-  }
+                        var cleanVal = newVal.replace(/[^0-9]+/g,"");
+                        if ( cleanVal == "" ) return;
 
-  if( window.CNPJ ) {
+                        console.log(" cleanVal =%o ", cleanVal);
+                        ctrl.$setValidity( 'cpf', CPF.isValid(cleanVal) );
+                    });
+                }
 
-    module.directive('ngCnpj', function() {
-      return {
+            };
+        });
+    }
 
-        restrict: 'A',
+    if( window.CNPJ ) {
 
-        require: 'ngModel',
+        module.directive('ngCnpj', function() {
+            return {
 
-        link: function(scope, elm, attrs, ctrl) {
-          scope.$watch(attrs.ngModel, function(newVal, oldVal) {
-            ctrl.$setValidity( 'cnpj', CNPJ.isValid(newVal) );
-          });
-        }
+                restrict: 'A',
 
-      };
-    });
-  }
+                require: 'ngModel',
+
+                link: function(scope, elm, attrs, ctrl) {
+                    scope.$watch(attrs.ngModel, function(newVal, oldVal) {
+                        if ( newVal == null ) {
+                            ctrl.$setValidity( 'cpf', true );
+                            return;
+                        }
+
+                        var cleanVal = newVal.replace(/[^0-9]+/g,"");
+                        if ( cleanVal == "" ) return;
+
+                        ctrl.$setValidity( 'cnpj', CNPJ.isValid(cleanVal) );
+                    });
+                }
+
+            };
+        });
+    }
 
 })(this);


### PR DESCRIPTION
Em alguns casos os campos CNPJ ou CPF devem ser opcionais. Ou seja, devem ser validados apenas se algum valor for fornecido.

Fiz com que a validação deixasse de ocorrer caso o valor fornecido fosse vazio ou nulo.

Entendo que para tornar o campo obrigatório, bastaria acrescentar o atributo "required" na tag <input>, certo?
